### PR TITLE
Continue migration script update

### DIFF
--- a/ckanext/bcgov_schema/bcdc_dataset.json
+++ b/ckanext/bcgov_schema/bcdc_dataset.json
@@ -804,6 +804,10 @@
         {
           "value": "NA",
           "label": "Not Applicable"
+        },
+        {
+          "value": "UNKNOWN",
+          "label": "Unknown"
         }
       ]
     },

--- a/ckanext/bcgov_schema/bcdc_dataset.json
+++ b/ckanext/bcgov_schema/bcdc_dataset.json
@@ -963,6 +963,10 @@
         {
           "value": "utm",
           "label": "UTM"
+        },
+        {
+          "value": "unknown",
+          "label": "Unknown"
         }
       ]
     },

--- a/ckanext/bcgov_schema/bcdc_dataset.json
+++ b/ckanext/bcgov_schema/bcdc_dataset.json
@@ -510,7 +510,7 @@
       "required": false
     },
     {
-      "field_name": "supplemental_information",
+      "field_name": "supplemental_info",
       "label": "Supplemental Information",
       "form_snippet": "markdown.html",
       "display_snippet": "markdown.html",

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -307,7 +307,7 @@ async function main() {
 					resource['extras']['projection_name'] = 'unknown';
 				}
 				if (!('spatial_datatype' in resource['extras']) && resourceType === 'geographic' && !makeService) {
-					resource['extras']['spatial_datatype'] = 'NA';
+					resource['extras']['spatial_datatype'] = 'UNKNOWN';
 				}
 				if (!('iso_topic_category' in resource['extras']) && resourceType === 'geographic' && !makeService) {
 					resource['extras']['iso_topic_category'] = JSON.stringify(['unknown']);

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -68,7 +68,7 @@ const extra_keys = "("
 	+ ")";
 
 function renameField(object, oldName, newName, mappingFunction = f => f) {
-	return object.newName = mappingFunction(oldName)
+	object.newName = mappingFunction(oldName)
 }
 
 async function main() {

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -160,13 +160,9 @@ async function main() {
 				}
 			}
 
-			if (!hasCreatedDate) {
+			if (!hasCreatedDate && (resourceType == 'webservice' ||  resourceType ===  'application')) {
 				packageExtras['dates'].push({"type": "Created", "date": packageExtras['record_create_date']});
 			}
-
-			// if (resource['extras']['bcdc_type'] === 'webservice' || resource['extras']['bcdc_type'] === 'application') {
-			// 	packageExtras['dates'].push({"type": "Created", "date": packageExtras['record_create_date']});
-			// }
 
 			packageExtras['more_info'] = [];
 			for (const key in moreInfoObj) {
@@ -306,23 +302,18 @@ async function main() {
 
 				if (makeService) resource['extras']['resource_storage_location'] = 'bc geographic warehouse';
 				if (resourceType === 'geographic' && resource['name'] === 'BC Geographic Warehouse Custom Download') resource['extras']['resource_storage_location'] = 'bc geographic warehouse';
-				if (!('resource_storage_location' in resource['extras'])) {
-					if (resourceType === 'webservice' || resourceType === 'application') {
-						resource['extras']['resource_storage_location'] = 'na';
-					}
-
-					// if (resourceType === 'document') resource['extras']['resource_storage_location'] = 'catalogue data store';
-					// else if (resourceType === 'geographic' && !makeService) resource['extras']['resource_storage_location'] = 'bc geographic warehouse';
-					// else resource['extras']['resource_storage_location'] = 'web or ftp site';
+				if (resourceType === 'webservice' || resourceType === 'application') {
+					resource['extras']['resource_storage_location'] = 'na';
 				}
+
 				if (!('resource_access_method' in resource['extras'])) {
 					resource['extras']['resource_access_method'] = 'direct access';
 				}
-				if (!('projection_name' in resource['extras']) && resourceType === 'geographic' && !makeService) {
-					resource['extras']['projection_name'] = 'epsg3005';
+				if (!('projection_name' in resource['extras']) && resourceType === 'geographic' && !makeService && resource['state'] != 'deleted') {
+					// resource['extras']['projection_name'] = 'epsg3005';
 				}
 				if (!('spatial_datatype' in resource['extras']) && resourceType === 'geographic' && !makeService) {
-					resource['extras']['spatial_datatype'] = 'SDO_GEOMETRY';
+					resource['extras']['spatial_datatype'] = 'NA';
 				}
 				if (!('iso_topic_category' in resource['extras']) && resourceType === 'geographic' && !makeService) {
 					resource['extras']['iso_topic_category'] = JSON.stringify(['unknown']);

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -68,7 +68,7 @@ const extra_keys = "("
 	+ ")";
 
 function renameField(object, oldName, newName, mappingFunction = f => f) {
-	object.newName = mappingFunction(oldName)
+	object[newName] = mappingFunction(object[oldName])
 }
 
 async function main() {
@@ -232,7 +232,7 @@ async function main() {
 				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'] == 'BCGW Datastore' ? 'bc geographic warehouse' : resource['extras']['resource_storage_location'].toLowerCase();
 				if (resource['extras']['supplemental_info']) renameField(resource['extras'], 'supplemental_info', 'supplemental_information')
 				delete resource['extras']['supplemental_info'];
-				if (resource['extras']['edc_resource_type']) renameField(resource, 'edc_resource_type', 'resource_type', f => f.toLowerCase())
+				if (resource['extras']['edc_resource_type']) resource['resource_type'] = resource['extras']['edc_resource_type'].toLowerCase();
 				delete resource['extras']['edc_resource_type']
 
 				// Information was duplicated in package.type which is now available as resource.extras.bcdc_type

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -202,10 +202,10 @@ async function main() {
 
 			// Resources query and setting empty objects for composite fields
 			let resourceRes = await pool.query("SELECT * from resource WHERE package_id = $1", [packageObj['id']]);
-			let temporalExtent = {};
 
 			// Iterate over resources and assign relevant fields to an object
 			resourceRes.rows.forEach(function(resource) {
+				let temporalExtent = {};
 				resource['extras'] = JSON.parse(resource['extras']) || {};
 				if ('data_collection_start_date' in resource['extras']) {
 					temporalExtent['beginning_date'] = resource['extras']['data_collection_start_date'];
@@ -456,7 +456,7 @@ async function main() {
 		// console.log('All Finished ¯\\_(ツ)_/¯');
 		process.exit();
 	} catch(err) {
-		console.log(err);
+		console.error(err);
 	}
 }
 

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -71,7 +71,6 @@ function renameField(object, oldName, newName, mappingFunction = f => f) {
 	return object.newName = mappingFunction(oldName)
 }
 
-
 async function main() {
 	try {
 		let res = await pool.query('SELECT * FROM package');
@@ -247,6 +246,7 @@ async function main() {
 				let resourceId = resource['id'];
 				delete resource['id'];
 
+				// Moving WMS and KML resources to type webservice
 				let makeService = (resourceType === 'geographic' && (resource['name'] === 'WMS getCapabilities request' || resource['name'] === 'KML Network Link'));
 				if (resourceType) resource['extras']['bcdc_type'] = makeService ? 'webservice' : resourceType;
 

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -46,14 +46,14 @@ const proj_name = {
 };
 
 function renameFieldIfExists(object, oldName, newName, mappingFunction = f => f) {
-	if (object[oldName]) {
+	if (oldName in object) {
 		object[newName] = mappingFunction(object[oldName]);
 		delete object[oldName];
 	}
 }
 
 function moveFieldIfExists(oldObject, newObject, fieldName) {
-	if (oldObject[fieldName]) {
+	if (fieldName in oldObject) {
 		newObject[fieldName] = oldObject[fieldName];
 		delete oldObject[fieldName];
 	}
@@ -76,9 +76,6 @@ async function main() {
 			}
 
 			// Assign sane defaults to package (not extras) that are required, if unset
-			if (!('title' in packageObj)) {
-				packageObj['title'] = packageObj['name'];
-			}
 			if (!('notes' in packageObj)) {
 				packageObj['notes'] = 'This field is required and needs to be updated';
 			}

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -244,13 +244,16 @@ async function main() {
 
 				let makeService = (resourceType === 'geographic' && (resource['name'] === 'WMS getCapabilities request' || resource['name'] === 'KML Network Link'));
 				if (resourceType) resource['extras']['bcdc_type'] = makeService ? 'webservice' : resourceType;
-				if (previewInformation && !makeService) resource['extras']['preview_info'] = JSON.stringify(previewInformation);
-				if (geographicExtent && !makeService) resource['extras']['geographic_extent'] = JSON.stringify(geographicExtent);
-				if (packageExtras['iso_topic_string'] && !makeService) resource['extras']['iso_topic_category'] = JSON.stringify(packageExtras['iso_topic_string'].split(','));
-				if (packageExtras['object_name'] && !makeService) resource['extras']['object_name'] = packageExtras['object_name'];
-				if (packageExtras['object_short_name'] && !makeService) resource['extras']['object_short_name'] = packageExtras['object_short_name'];
-				if (packageExtras['object_table_comments'] && !makeService) resource['extras']['object_table_comments'] = packageExtras['object_table_comments'];
-				if (packageExtras['spatial_datatype'] && !makeService) resource['extras']['spatial_datatype'] = packageExtras['spatial_datatype'];
+
+				if (!makeService) {
+					if (previewInformation) resource['extras']['preview_info'] = JSON.stringify(previewInformation);
+					if (geographicExtent) resource['extras']['geographic_extent'] = JSON.stringify(geographicExtent);
+					if (packageExtras['iso_topic_string']) resource['extras']['iso_topic_category'] = JSON.stringify(packageExtras['iso_topic_string'].split(','));
+					if (packageExtras['object_name']) resource['extras']['object_name'] = packageExtras['object_name'];
+					if (packageExtras['object_short_name']) resource['extras']['object_short_name'] = packageExtras['object_short_name'];
+					if (packageExtras['object_table_comments']) resource['extras']['object_table_comments'] = packageExtras['object_table_comments'];
+					if (packageExtras['spatial_datatype']) resource['extras']['spatial_datatype'] = packageExtras['spatial_datatype'];
+				}
 
 				if (makeService) {
 					if (resource['extras']['projection_name']) delete resource['extras']['projection_name'];

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -75,9 +75,6 @@ async function main() {
 			}
 
 			// Assign sane defaults to package (not extras) that are required, if unset
-			if (!('name' in packageObj)) {
-				packageObj['name'] = packageObj['id'];
-			}
 			if (!('title' in packageObj)) {
 				packageObj['title'] = packageObj['name'];
 			}

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -171,6 +171,11 @@ async function main() {
 					east_bound_longitude: packageExtras['east_bound_longitude'] || '',
 					west_bound_longitude: packageExtras['west_bound_longitude'] || ''
 				};
+
+				delete packageExtras['north_bound_latitude'];
+				delete packageExtras['south_bound_latitude'];
+				delete packageExtras['east_bound_longitude'];
+				delete packageExtras['west_bound_longitude'];
 			}
 			let previewInformation;
 			if ('preview_latitude' in packageExtras || 'preview_longitude' in packageExtras
@@ -187,6 +192,15 @@ async function main() {
 					layer_name: packageExtras['layer_name'] || '',
 					image_url: packageExtras['image_url'] || ''
 				};
+
+				delete packageExtras['preview_latitude'];
+				delete packageExtras['preview_longitude'];
+				delete packageExtras['preview_map_service_url'];
+				delete packageExtras['preview_zoom_level'];
+				delete packageExtras['preview_image_url'];
+				delete packageExtras['link_to_imap'];
+				delete packageExtras['layer_name'];
+				delete packageExtras['image_url'];
 			}
 
 			// Resources query and setting empty objects for composite fields

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -225,7 +225,6 @@ async function main() {
 				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'].toLowerCase();
 				if (resource['extras']['resource_storage_location'] === 'bcgw datastore') resource['extras']['resource_storage_location'] = 'bc geographic warehouse';
 								
-				renameFieldIfExists(resource['extras'], 'supplemental_info', 'supplemental_information');
 				renameFieldIfExists(resource['extras'], 'edc_resource_type', 'resource_type', f => f.toLowerCase());
 				moveFieldIfExists(resource['extras'], resource, 'resource_type');
 				delete resource['extras']['resource_type'];
@@ -343,24 +342,6 @@ async function main() {
 									"VALUES ($4, $1, 'resource_status', $2, $3, 'active')", 
 									[packageObj['id'], packageExtras['resource_status'], packageObj['revision_id'], uuidv4()]);
 			}
-			if (packageExtras['resource_status'] === 'obsolete' && !('replacement_record' in packageExtras)) {
-				packageExtras['replacement_record'] = null;
-				await pool.query("INSERT INTO package_extra (id, package_id, key, value, revision_id, state)" +
-									"VALUES ($4, $1, 'replacement_record', $2, $3, 'active')", 
-									[packageObj['id'], packageExtras['replacement_record'], packageObj['revision_id'], uuidv4()]);
-			}
-			if (packageExtras['resource_status'] === 'historicalArchive' && !('retention_expiry_date' in packageExtras)) {
-				packageExtras['retention_expiry_date'] = null;
-				await pool.query("INSERT INTO package_extra (id, package_id, key, value, revision_id, state)" +
-									"VALUES ($4, $1, 'retention_expiry_date', $2, $3, 'active')", 
-									[packageObj['id'], packageExtras['retention_expiry_date'], packageObj['revision_id'], uuidv4()]);
-			}
-			if (packageExtras['resource_status'] === 'historicalArchive' && !('source_data_path' in packageExtras)) {
-				packageExtras['source_data_path'] = null;
-				await pool.query("INSERT INTO package_extra (id, package_id, key, value, revision_id, state)" +
-									"VALUES ($4, $1, 'source_data_path', $2, $3, 'active')", 
-									[packageObj['id'], packageExtras['source_data_path'], packageObj['revision_id'], uuidv4()]);
-			}
 			if (!('view_audience' in packageExtras)) {
 				packageExtras['view_audience'] = 'Government';
 				await pool.query("INSERT INTO package_extra (id, package_id, key, value, revision_id, state)" +
@@ -445,7 +426,7 @@ async function main() {
 			// Delete all keys that have been migrated/renamed in package_extra
 			const packageKeys = "('" + Object.keys(packageExtras).join("', '") + "')";
 
-			await pool.query("DELETE FROM package_extra_revision WHERE package_id = $1 AND key NOT IN " + packageKeys, [packageObj['id']]);
+			// await pool.query("DELETE FROM package_extra_revision WHERE package_id = $1 AND key NOT IN " + packageKeys, [packageObj['id']]);
 			await pool.query("DELETE FROM package_extra WHERE package_id = $1 AND key NOT IN " + packageKeys, [packageObj['id']]);
 
 			// Update package

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -352,13 +352,13 @@ async function main() {
 									"VALUES ($4, $1, 'replacement_record', $2, $3, 'active')", 
 									[packageObj['id'], packageExtras['replacement_record'], packageObj['revision_id'], uuidv4()]);
 			}
-			if (packageExtras['resource_status'] === 'historical_archive' && !('retention_expiry_date' in packageExtras)) {
+			if (packageExtras['resource_status'] === 'historicalArchive' && !('retention_expiry_date' in packageExtras)) {
 				packageExtras['retention_expiry_date'] = null;
 				await pool.query("INSERT INTO package_extra (id, package_id, key, value, revision_id, state)" +
 									"VALUES ($4, $1, 'retention_expiry_date', $2, $3, 'active')", 
 									[packageObj['id'], packageExtras['retention_expiry_date'], packageObj['revision_id'], uuidv4()]);
 			}
-			if (packageExtras['resource_status'] === 'historical_archive' && !('source_data_path' in packageExtras)) {
+			if (packageExtras['resource_status'] === 'historicalArchive' && !('source_data_path' in packageExtras)) {
 				packageExtras['source_data_path'] = null;
 				await pool.query("INSERT INTO package_extra (id, package_id, key, value, revision_id, state)" +
 									"VALUES ($4, $1, 'source_data_path', $2, $3, 'active')", 
@@ -416,6 +416,7 @@ async function main() {
 
 					case "LOW-PUBLIC":
 						packageExtras['security_class'] = 'PUBLIC';
+						break;
 
 					default:
 						throw `Package with missing/invalid security_class: ${packageObj['id']}`;
@@ -458,7 +459,7 @@ async function main() {
 		// console.log('All Finished ¯\\_(ツ)_/¯');
 		process.exit();
 	} catch(err) {
-		console.log(err.stack);
+		console.log(err);
 	}
 }
 

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -441,7 +441,7 @@ async function main() {
 
 			// Delete all keys that have been migrated/renamed in package_extra
 			const query = ['DELETE FROM'];
-			query.push('package_extra');
+			query.push('package_extra_revision');
 			query.push('WHERE package_id = $1');
 			query.push('AND key NOT IN');
 
@@ -459,6 +459,9 @@ async function main() {
 			query.push(set.join(', '));
 			query.push(')');
 
+			await pool.query(query.join(' '), values);
+
+			query[1] = 'package_extra';
 			await pool.query(query.join(' '), values);
 
 			// Update package

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -69,6 +69,7 @@ const extra_keys = "("
 
 function renameField(object, oldName, newName, mappingFunction = f => f) {
 	object[newName] = mappingFunction(object[oldName])
+	delete object[oldName];
 }
 
 async function main() {
@@ -228,10 +229,8 @@ async function main() {
 				resource['extras']['temporal_extent'] = JSON.stringify(temporalExtent);
 				if (proj_name[resource['extras']['projection_name']]) resource['extras']['projection_name'] = proj_name[resource['extras']['projection_name']];
 				if (resource['extras']['resource_storage_access_method']) renameField(resource['extras'], 'resource_storage_access_method', 'resource_access_method', f => f.toLowerCase());
-				delete resource['extras']['resource_storage_access_method']
 				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'] == 'BCGW Datastore' ? 'bc geographic warehouse' : resource['extras']['resource_storage_location'].toLowerCase();
 				if (resource['extras']['supplemental_info']) renameField(resource['extras'], 'supplemental_info', 'supplemental_information')
-				delete resource['extras']['supplemental_info'];
 				if (resource['extras']['edc_resource_type']) resource['resource_type'] = resource['extras']['edc_resource_type'].toLowerCase();
 				delete resource['extras']['edc_resource_type']
 

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -45,28 +45,6 @@ const proj_name = {
 	"UTM": "utm"
 };
 
-const extra_keys = "("
-	+ "'publish_state', "
-	+ "'purpose', "
-	+ "'lineage_statement', "
-	+ "'data_quality', "
-	+ "'more_info', "
-	+ "'contacts', "
-	+ "'dates', "
-	+ "'resource_status', "
-	+ "'replacement_record', "
-	+ "'retention_exipry_date', "
-	+ "'source_data_path', "
-	+ "'view_audience', "
-	+ "'metadata_visibility', "
-	+ "'download_audience', "
-	+ "'security_class',"
-	+ "'record_publish_date',"
-	+ "'record_create_date',"
-	+ "'record_archive_date',"
-	+ "'record_last_modified'"
-	+ ")";
-
 function renameField(object, oldName, newName, mappingFunction = f => f) {
 	object[newName] = mappingFunction(object[oldName])
 	delete object[oldName];
@@ -439,9 +417,6 @@ async function main() {
 				uuidv4()//10
 			]
 			await pool.query(extrasUpdateSQL, extrasUpdateValues);
-
-			await pool.query("DELETE FROM package_extra_revision WHERE package_id = $1 AND key NOT IN " + extra_keys, [packageObj['id']]);
-			await pool.query("DELETE FROM package_extra WHERE package_id = $1 AND key NOT IN " + extra_keys, [packageObj['id']]);
 
 			// Update package
 			await pool.query("UPDATE package set type = 'bcdc_dataset' WHERE id = $1", [packageObj['id']]);

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -45,9 +45,17 @@ const proj_name = {
 	"UTM": "utm"
 };
 
-function renameField(object, oldName, newName, mappingFunction = f => f) {
-	object[newName] = mappingFunction(object[oldName])
-	delete object[oldName];
+function renameFieldIfExists(object, oldName, newName, mappingFunction = f => f) {
+	if (object[oldName]) {
+		object[newName] = mappingFunction(object[oldName])
+		delete object[oldName];
+	}
+}
+
+function moveFieldIfExists(oldObject, newObject, fieldName) {
+	if (oldObject[fieldName]) {
+		newObject[fieldName] = oldObject[fieldName]
+	}
 }
 
 async function main() {
@@ -206,9 +214,9 @@ async function main() {
 				}
 				resource['extras']['temporal_extent'] = JSON.stringify(temporalExtent);
 				if (proj_name[resource['extras']['projection_name']]) resource['extras']['projection_name'] = proj_name[resource['extras']['projection_name']];
-				if (resource['extras']['resource_storage_access_method']) renameField(resource['extras'], 'resource_storage_access_method', 'resource_access_method', f => f.toLowerCase());
+				renameFieldIfExists(resource['extras'], 'resource_storage_access_method', 'resource_access_method', f => f.toLowerCase());
 				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'] == 'BCGW Datastore' ? 'bc geographic warehouse' : resource['extras']['resource_storage_location'].toLowerCase();
-				if (resource['extras']['supplemental_info']) renameField(resource['extras'], 'supplemental_info', 'supplemental_information')
+				renameFieldIfExists(resource['extras'], 'supplemental_info', 'supplemental_information')
 				if (resource['extras']['edc_resource_type']) resource['resource_type'] = resource['extras']['edc_resource_type'].toLowerCase();
 				delete resource['extras']['edc_resource_type']
 
@@ -231,10 +239,12 @@ async function main() {
 					if (previewInformation) resource['extras']['preview_info'] = JSON.stringify(previewInformation);
 					if (geographicExtent) resource['extras']['geographic_extent'] = JSON.stringify(geographicExtent);
 					if (packageExtras['iso_topic_string']) resource['extras']['iso_topic_category'] = JSON.stringify(packageExtras['iso_topic_string'].split(','));
-					if (packageExtras['object_name']) resource['extras']['object_name'] = packageExtras['object_name'];
-					if (packageExtras['object_short_name']) resource['extras']['object_short_name'] = packageExtras['object_short_name'];
-					if (packageExtras['object_table_comments']) resource['extras']['object_table_comments'] = packageExtras['object_table_comments'];
-					if (packageExtras['spatial_datatype']) resource['extras']['spatial_datatype'] = packageExtras['spatial_datatype'];
+					renameFieldIfExists(packageExtras, 'iso_topic_string', 'iso_topic_category', f => JSON.stringify(f.split(',')));
+					moveFieldIfExists(packageExtras, resource, 'iso_topic_category');
+					moveFieldIfExists(packageExtras, resource, 'object_name');
+					moveFieldIfExists(packageExtras, resource, 'object_short_name');
+					moveFieldIfExists(packageExtras, resource, 'object_table_comments');
+					moveFieldIfExists(packageExtras, resource, 'spatial_datatype');
 				}
 
 				// Set sane defaults for required resource fields with missing

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -312,7 +312,7 @@ async function main() {
 					resource['extras']['resource_access_method'] = 'direct access';
 				}
 				if (!('projection_name' in resource['extras']) && resourceType === 'geographic' && !makeService && resource['state'] != 'deleted') {
-					// resource['extras']['projection_name'] = 'epsg3005';
+					resource['extras']['projection_name'] = 'unknown';
 				}
 				if (!('spatial_datatype' in resource['extras']) && resourceType === 'geographic' && !makeService) {
 					resource['extras']['spatial_datatype'] = 'NA';

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -55,6 +55,7 @@ function renameFieldIfExists(object, oldName, newName, mappingFunction = f => f)
 function moveFieldIfExists(oldObject, newObject, fieldName) {
 	if (oldObject[fieldName]) {
 		newObject[fieldName] = oldObject[fieldName];
+		delete oldObject[fieldName];
 	}
 }
 
@@ -233,6 +234,7 @@ async function main() {
 				let makeService = (resourceType === 'geographic' && (resource['name'] === 'WMS getCapabilities request' || resource['name'] === 'KML Network Link'));
 				if (resourceType) resource['extras']['bcdc_type'] = makeService ? 'webservice' : resourceType;
 
+				// Moving geographic data from the package level to the resource level
 				if (resourceType === 'geographic') {
 					if (previewInformation) resource['extras']['preview_info'] = JSON.stringify(previewInformation);
 					if (geographicExtent) resource['extras']['geographic_extent'] = JSON.stringify(geographicExtent);

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -160,6 +160,7 @@ async function main() {
 				}
 			}
 
+			// Most webservices and applications did not have created dates, but this is now a required field
 			if (!hasCreatedDate && (resourceType == 'webservice' ||  resourceType ===  'application')) {
 				packageExtras['dates'].push({"type": "Created", "date": packageExtras['record_create_date']});
 			}
@@ -230,6 +231,7 @@ async function main() {
 				if (resource['extras']['edc_resource_type']) resource['resource_type'] = resource['extras']['edc_resource_type'].toLowerCase();
 				delete resource['extras']['edc_resource_type']
 
+				// Information was duplicated in package.type which is now available as resource.extras.bcdc_type
 				delete resource['extras']['type']
 				
 				resources.push(resource);

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -106,8 +106,6 @@ async function main() {
 						contactsObj[keyComponents[1]]['org'] = packageExtra['value'];
 					} else if (keyComponents[2] != 'organization') {
 						contactsObj[keyComponents[1]][keyComponents[2]] = packageExtra['value'];
-					} else if (keyComponents[2] != 'organization') {
-						contactsObj[keyComponents[1]][keyComponents[2]] = packageExtra['value'];
 					}
 				} else if (packageExtra['key'].match(/dates\:/g)) {
 					let keyComponents = packageExtra['key'].split(':');
@@ -215,7 +213,9 @@ async function main() {
 				resource['extras']['temporal_extent'] = JSON.stringify(temporalExtent);
 				if (proj_name[resource['extras']['projection_name']]) resource['extras']['projection_name'] = proj_name[resource['extras']['projection_name']];
 				renameFieldIfExists(resource['extras'], 'resource_storage_access_method', 'resource_access_method', f => f.toLowerCase());
-				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'] == 'BCGW Datastore' ? 'bc geographic warehouse' : resource['extras']['resource_storage_location'].toLowerCase();
+				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'].toLowerCase();
+				if (resource['extras']['resource_storage_location'] === 'bcgw datastore') resource['extras']['resource_storage_location'] = 'bc geographic warehouse'
+								
 				renameFieldIfExists(resource['extras'], 'supplemental_info', 'supplemental_information')
 				if (resource['extras']['edc_resource_type']) resource['resource_type'] = resource['extras']['edc_resource_type'].toLowerCase();
 				delete resource['extras']['edc_resource_type']
@@ -238,7 +238,6 @@ async function main() {
 				if (resourceType === 'geographic') {
 					if (previewInformation) resource['extras']['preview_info'] = JSON.stringify(previewInformation);
 					if (geographicExtent) resource['extras']['geographic_extent'] = JSON.stringify(geographicExtent);
-					if (packageExtras['iso_topic_string']) resource['extras']['iso_topic_category'] = JSON.stringify(packageExtras['iso_topic_string'].split(','));
 					renameFieldIfExists(packageExtras, 'iso_topic_string', 'iso_topic_category', f => JSON.stringify(f.split(',')));
 					moveFieldIfExists(packageExtras, resource, 'iso_topic_category');
 					moveFieldIfExists(packageExtras, resource, 'object_name');

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -67,6 +67,11 @@ const extra_keys = "("
 	+ "'record_last_modified'"
 	+ ")";
 
+function renameField(object, oldName, newName, mappingFunction = f => f) {
+	return object.newName = mappingFunction(oldName)
+}
+
+
 async function main() {
 	try {
 		let res = await pool.query('SELECT * FROM package');
@@ -223,12 +228,12 @@ async function main() {
 				}
 				resource['extras']['temporal_extent'] = JSON.stringify(temporalExtent);
 				if (proj_name[resource['extras']['projection_name']]) resource['extras']['projection_name'] = proj_name[resource['extras']['projection_name']];
-				if (resource['extras']['resource_storage_access_method']) resource['extras']['resource_access_method'] = resource['extras']['resource_storage_access_method'].toLowerCase();
+				if (resource['extras']['resource_storage_access_method']) renameField(resource['extras'], 'resource_storage_access_method', 'resource_access_method', f => f.toLowerCase());
 				delete resource['extras']['resource_storage_access_method']
 				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'] == 'BCGW Datastore' ? 'bc geographic warehouse' : resource['extras']['resource_storage_location'].toLowerCase();
-				if (resource['extras']['supplemental_info']) resource['extras']['supplemental_information'] = resource['extras']['supplemental_info'];
+				if (resource['extras']['supplemental_info']) renameField(resource['extras'], 'supplemental_info', 'supplemental_information')
 				delete resource['extras']['supplemental_info'];
-				if (resource['extras']['edc_resource_type']) resource['resource_type'] = resource['extras']['edc_resource_type'].toLowerCase();
+				if (resource['extras']['edc_resource_type']) renameField(resource, 'edc_resource_type', 'resource_type', f => f.toLowerCase())
 				delete resource['extras']['edc_resource_type']
 
 				// Information was duplicated in package.type which is now available as resource.extras.bcdc_type

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -210,7 +210,8 @@ async function main() {
 				}
 				resource['extras']['temporal_extent'] = JSON.stringify(temporalExtent);
 				if (proj_name[resource['extras']['projection_name']]) resource['extras']['projection_name'] = proj_name[resource['extras']['projection_name']];
-				if (resource['extras']['resource_storage_access_method']) resource['extras']['resource_storage_access_method'] = resource['extras']['resource_storage_access_method'].toLowerCase();
+				if (resource['extras']['resource_storage_access_method']) resource['extras']['resource_access_method'] = resource['extras']['resource_storage_access_method'].toLowerCase();
+				delete resource['extras']['resource_storage_access_method']
 				if (resource['extras']['resource_storage_location']) resource['extras']['resource_storage_location'] = resource['extras']['resource_storage_location'] == 'BCGW Datastore' ? 'bc geographic warehouse' : resource['extras']['resource_storage_location'].toLowerCase();
 				if (resource['extras']['supplemental_info']) resource['extras']['supplemental_information'] = resource['extras']['supplemental_info'];
 				delete resource['extras']['supplemental_info'];

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -292,6 +292,13 @@ async function main() {
 					resource['format'] = 'other'
 				}
 
+				// Webservices and applications did not have a resource_access_method
+				if (resource['extras']['bcdc_type'] === 'webservice') {
+					resource['extras']['resource_access_method'] = 'service';
+				} else if(resource['extras']['bcdc_type'] === 'application') {
+					resource['extras']['resource_access_method'] = 'application';
+				}
+
 				if (resource['extras']['bcdc_type'] === 'geographic' && ['csv', 'json', 'pdf', 'xml', 'html', 'xls', 'xlsx', 'atom', 'txt'].includes(resource['format'])) {
 					resource['extras']['bcdc_type'] = 'document';
 					resource['format'] = 'other';

--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -249,7 +249,7 @@ async function main() {
 				let makeService = (resourceType === 'geographic' && (resource['name'] === 'WMS getCapabilities request' || resource['name'] === 'KML Network Link'));
 				if (resourceType) resource['extras']['bcdc_type'] = makeService ? 'webservice' : resourceType;
 
-				if (!makeService) {
+				if (resourceType === 'geographic') {
 					if (previewInformation) resource['extras']['preview_info'] = JSON.stringify(previewInformation);
 					if (geographicExtent) resource['extras']['geographic_extent'] = JSON.stringify(geographicExtent);
 					if (packageExtras['iso_topic_string']) resource['extras']['iso_topic_category'] = JSON.stringify(packageExtras['iso_topic_string'].split(','));
@@ -257,11 +257,6 @@ async function main() {
 					if (packageExtras['object_short_name']) resource['extras']['object_short_name'] = packageExtras['object_short_name'];
 					if (packageExtras['object_table_comments']) resource['extras']['object_table_comments'] = packageExtras['object_table_comments'];
 					if (packageExtras['spatial_datatype']) resource['extras']['spatial_datatype'] = packageExtras['spatial_datatype'];
-				}
-
-				if (makeService) {
-					if (resource['extras']['projection_name']) delete resource['extras']['projection_name'];
-					if (resource['extras']['details']) delete resource['extras']['details'];
 				}
 
 				// Set sane defaults for required resource fields with missing
@@ -296,20 +291,6 @@ async function main() {
 					resource['extras']['resource_access_method'] = 'service';
 				} else if(resource['extras']['bcdc_type'] === 'application') {
 					resource['extras']['resource_access_method'] = 'application';
-				}
-
-				if (resource['extras']['bcdc_type'] === 'geographic' && ['csv', 'json', 'pdf', 'xml', 'html', 'xls', 'xlsx', 'atom', 'txt'].includes(resource['format'])) {
-					resource['extras']['bcdc_type'] = 'document';
-					resource['format'] = 'other';
-					resource['extras']['spatial_datatype'] = 'na';
-					resource['extras']['object_name'] = '';
-					resource['extras']['object_short_name'] = '';
-					resource['extras']['details'] = '';
-					resource['extras']['projection_name'] = '';
-					resource['extras']['iso_topic_category'] = '';
-					
-					resource['extras']['geographic_extent'] = '{}';
-					resource['extras']['preview_info'] = '{}';
 				}
 
 				if (resource['resource_type'] === '' || resource['resource_type'] === null) {


### PR DESCRIPTION
## Update resource_access_method (DDS-516)
The field resource_access_storage_method has been renamed to resource_access_method.
Additionally, webservices and applications need this field added.
## ~~Update bcdc_type (DDS-503)~~
Removed due to concerns of loss of relevant information
## Remove resource.extras.type (DDS-527)
The information in this field was duplicated from package.type, which has now been moved to the resource level and is available as resource.extras.bcdc_type, removing the need for this field.
## Add Created dates (DDS-500)
Applications and webservices did not have a created date, but this is now a mandatory field and is being set to the date the record was created in the catalogue.
## Set record_status (DDS-577)
Updated default if missing to onGoing and updated replacement_record to null on 'obsolete' resource_status
Set retention_expiry_date and source_data_path to null for 'historicalArchive' resource_status
## Update security_class switch (DDS-578)
Add a switch case for PUBLIC and set default to throw an error.