### PR TITLE
Changed notes field to description (ckan core) for groups/orgs

### DIFF
--- a/ckanext/bcgov_schema/group.json
+++ b/ckanext/bcgov_schema/group.json
@@ -19,7 +19,7 @@
       "form_placeholder": "my-group"
     },
     {
-      "field_name": "notes",
+      "field_name": "description",
       "label": "Description",
       "form_snippet": "markdown.html",
       "form_placeholder": "A little information about my group..."

--- a/ckanext/bcgov_schema/organization.json
+++ b/ckanext/bcgov_schema/organization.json
@@ -26,7 +26,7 @@
       "required": true
     },
     {
-      "field_name": "notes",
+      "field_name": "description",
       "label": "Description",
       "form_snippet": "markdown.html",
       "form_placeholder": "A little information about my group..."


### PR DESCRIPTION
Per bcgov/ckan-ui#495, the groups and organizations should probably store their descriptions in the built-in description field instead of creating a parallel notes field for the same purpose. This pull request is the first of several steps to resolve an outstanding bug where descriptions aren't showing up in the UI or updates to descriptions are going nowhere.

1. Update the schema **← this pull request**
2. Update the ckanext-bcgov repo to reference this latest commit hash in requirements.txt
3. Update ckan-ui to use description instead of notes in all the places instead of just some of the places