### PR TITLE
Truncate follow tables

### DIFF
--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -471,6 +471,9 @@ async function main() {
 		await pool.query("DELETE FROM package_extra_revision");
 		await pool.query("DELETE FROM package_revision");
 		await pool.query("DELETE FROM resource_revision");
+		
+		// remove all existing follows due to incompatibilities with new UI
+		await pool.query("TRUNCATE user_following_dataset, user_following_group, user_following_user");
 
 		process.stdout.write("Done! ¯\\_(ツ)_/¯\n");
 		// console.log('All Finished ¯\\_(ツ)_/¯');


### PR DESCRIPTION
At the present time, the follow feature is incompatible with the new UI's activity streams; it identifies authorship incorrectly and causes other issues on the user page. I've added a line to truncate existing follower tables. In conjunction with in-development UI updates to remove the follow feature, this will limit the impact of the bug pending full resolution.