### PR TITLE
Specify that package extra fields must be active

### DIFF
--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -85,7 +85,7 @@ async function main() {
 			}
 
 			// Extras for the package and empty objects for the compostite fields
-			let extrasRes = await pool.query("SELECT key, value FROM package_extra WHERE package_id = $1", [packageObj['id']]);
+			let extrasRes = await pool.query("SELECT key, value FROM package_extra WHERE package_id = $1 and state = 'active'", [packageObj['id']]);
 			let contactsObj = {};
 			let datesObj = {};
 			let moreInfoObj = {};


### PR DESCRIPTION
If we don't filter by state, repeating fields get undeleted when they're ported over.