### PR TITLE
Add download audience of NA to webservices and applications

### DIFF
--- a/scripts/scheming_migration/index.js
+++ b/scripts/scheming_migration/index.js
@@ -151,7 +151,7 @@ async function main() {
 					packageExtras['dates'].push({"type": "Created", "date": packageExtras['record_create_date']});
 				}
 
-				packageExtras['download_audience'] = 'NA'
+				packageExtras['download_audience'] = 'NA';
 			}
 
 			packageExtras['more_info'] = [];


### PR DESCRIPTION
DDS-647 - Who can download this?
download_audience is now a field applied to webservices and applications but they are not downloadable resources, so a NA option was added and is now being set as default for these resources.