### PR TITLE
Dds#1027

### DIFF
--- a/ckanext/bcgov_schema/bcdc_dataset.json
+++ b/ckanext/bcgov_schema/bcdc_dataset.json
@@ -877,7 +877,7 @@
       "preset": "select",
       "sorted_choices": false,
       "conditional_field": "bcdc_type",
-      "conditional_values": ["geographic"],
+      "conditional_values": ["geographic","webservice"],
       "validators": "conditional_required",
       "form_include_blank_choice": true,
       "help_text": "Spatial reference system as defined by ESPG, e.g., BCGW data is primarily ESPG-3005 - NAD83 BC Albers.",
@@ -885,6 +885,10 @@
         {
           "value": "epsg3005",
           "label": "EPSG_3005 - NAD83 BC Albers"
+        },
+        {
+          "value": "epsg3153",
+          "label": "EPSG_3153 - NAD83(CSRS) BC Albers"
         },
         {
           "value": "epsg3857",

--- a/ckanext/bcgov_schema/bcdc_dataset.json
+++ b/ckanext/bcgov_schema/bcdc_dataset.json
@@ -820,8 +820,6 @@
     {
       "field_name": "object_name",
       "label": "Object Name",
-      "conditional_field": "bcdc_type",
-      "conditional_values": ["geographic"],
       "help_text": "Name of schema and table stored in a database."
     },
     {

--- a/ckanext/bcgov_schema/bcdc_dataset.json
+++ b/ckanext/bcgov_schema/bcdc_dataset.json
@@ -827,12 +827,16 @@
     {
       "field_name": "object_short_name",
       "label": "Object Short Name",
+      "conditional_field": "resource_storage_location",
+      "conditional_value": ["bc geographic warehouse"],
       "form_snippet": null,
       "help_text": "Short name for certain file types, e.g., Shape files. Max 10 characters."
     },
     {
       "field_name": "object_table_comments",
       "label": "Object Table Comments",
+      "conditional_field": "resource_storage_location",
+      "conditional_value": ["bc geographic warehouse"],
       "form_snippet": null,
       "help_text": "Object defintion as defined in the storage location database."
     },
@@ -841,6 +845,8 @@
       "label": "Details",
       "display_snippet": "bcgw_details.html",
       "validators": "composite_repeating_group2json",
+      "conditional_field": "resource_storage_location",
+      "conditional_value": ["bc geographic warehouse"],
       "form_snippet": null,
       "required": false,
       "help_text": "Field definition including name, short name, length, field type and description for a dataset in the BCGW.",


### PR DESCRIPTION
Change the following to use the BCGW storage location to show field or not: object_short_name, object_table_comment, details. Made object_name visible to all bcdc_types. Added ESPG 3153 to projection and made projection visible to both geographic and webservice.